### PR TITLE
[WIP] FrequencyObservable is a function returning an Observable

### DIFF
--- a/packages/light.js/src/frequency/accounts.ts
+++ b/packages/light.js/src/frequency/accounts.ts
@@ -5,22 +5,22 @@
 
 import { AccountsInfo, Address, FrequencyObservable } from '../types';
 import api from '../api';
-import createOnFromPubsub from './utils/createOnFromPubsub';
+import createPubsubObservable from './utils/createPubsubObservable';
 
 /**
  * Observable that emits each time the default account changes
  */
-export const onAccountsChanged$ = createOnFromPubsub<Address[]>(
-  'eth_accounts',
-  api
-);
+export const onAccountsChanged$ = (() =>
+  createPubsubObservable('eth_accounts', api)) as FrequencyObservable<
+  Address[]
+>;
 onAccountsChanged$.metadata = { name: 'onAccountsChanged$' };
 
 /**
  * Observable that emits each time the default account changes
  */
-export const onAccountsInfoChanged$ = createOnFromPubsub<AccountsInfo>(
-  'parity_accountsInfo',
-  api
-);
+export const onAccountsInfoChanged$ = (() =>
+  createPubsubObservable('parity_accountsInfo', api)) as FrequencyObservable<
+  AccountsInfo
+>;
 onAccountsInfoChanged$.metadata = { name: 'onAccountsInfoChanged$' };

--- a/packages/light.js/src/frequency/blocks.ts
+++ b/packages/light.js/src/frequency/blocks.ts
@@ -7,30 +7,32 @@ import BigNumber from 'bignumber.js';
 import { filter } from 'rxjs/operators';
 
 import api from '../api';
-import createOnFromPubsub from './utils/createOnFromPubsub';
+import createPubsubObservable from './utils/createPubsubObservable';
 import { FrequencyObservable } from '../types';
 
 /**
  * Observable that emits on every new block.
  */
-export const onEveryBlock$ = createOnFromPubsub<BigNumber>(
-  'eth_blockNumber',
-  api
-);
+export const onEveryBlock$ = (() =>
+  createPubsubObservable('eth_blockNumber', api)) as FrequencyObservable<
+  BigNumber
+>;
 onEveryBlock$.metadata = { name: 'onEveryBlock$' };
 
 /**
  * Observable that emits on every 2nd block.
  */
-export const onEvery2Blocks$ = onEveryBlock$.pipe(
-  filter(n => +n % 2 === 0) // Around ~30s on mainnet // TODO Use isEqualTo and mod from bignumber.js
-) as FrequencyObservable<BigNumber>;
+export const onEvery2Blocks$ = (() =>
+  onEveryBlock$().pipe(
+    filter(n => +n % 2 === 0) // Around ~30s on mainnet // TODO Use isEqualTo and mod from bignumber.js
+  )) as FrequencyObservable<BigNumber>;
 onEvery2Blocks$.metadata = { name: 'onEvery2Blocks$' };
 
 /**
  * Observable that emits on every 4th block.
  */
-export const onEvery4Blocks$ = onEveryBlock$.pipe(
-  filter(n => +n % 4 === 0) // Around ~1min on mainnet // TODO Use isEqualTo and mod from bignumber.js
-) as FrequencyObservable<BigNumber>;
+export const onEvery4Blocks$ = (() =>
+  onEveryBlock$().pipe(
+    filter(n => +n % 4 === 0) // Around ~1min on mainnet // TODO Use isEqualTo and mod from bignumber.js
+  )) as FrequencyObservable<BigNumber>;
 onEvery4Blocks$.metadata = { name: 'onEvery4Blocks$' };

--- a/packages/light.js/src/frequency/health.ts
+++ b/packages/light.js/src/frequency/health.ts
@@ -4,13 +4,14 @@
 // SPDX-License-Identifier: MIT
 
 import api from '../api';
-import createOnFromPubsub from './utils/createOnFromPubsub';
+import createPubsubObservable from './utils/createPubsubObservable';
+import { FrequencyObservable } from '../types';
 
 /**
  * Observable that emits when syncing status changes.
  */
 // TODO Pubsub doesn't exist on `net_peerCount`
-// export const onPeersChange$ = createOnFromPubsub<number>('net_peerCount', api);
+// export const onPeersChange$ = createPubsubObservable<number>('net_peerCount', api);
 // onPeersChange$.metadata = {
 //   calls: ['net_peerCount'],
 //   name: 'onPeersChange$'
@@ -19,10 +20,10 @@ import createOnFromPubsub from './utils/createOnFromPubsub';
 /**
  * Observable that emits when syncing status changes.
  */
-export const onSyncingChanged$ = createOnFromPubsub<object | boolean>(
-  'eth_syncing',
-  api
-);
+export const onSyncingChanged$ = (() =>
+  createPubsubObservable('eth_syncing', api)) as FrequencyObservable<
+  object | boolean
+>;
 onSyncingChanged$.metadata = {
   calls: ['eth_syncing'],
   name: 'onSyncingChanged$'

--- a/packages/light.js/src/frequency/other.ts
+++ b/packages/light.js/src/frequency/other.ts
@@ -10,5 +10,5 @@ import { FrequencyObservable } from '../types';
 /**
  * Observable that emits only once.
  */
-export const onStartup$ = of(0) as FrequencyObservable<number>;
+export const onStartup$ = (() => of(0)) as FrequencyObservable<number>;
 onStartup$.metadata = { name: 'onStartup$' };

--- a/packages/light.js/src/frequency/time.ts
+++ b/packages/light.js/src/frequency/time.ts
@@ -10,17 +10,23 @@ import { FrequencyObservable } from '../types';
 /**
  * Observable that emits on every second.
  */
-export const onEverySecond$ = timer(0, 1000) as FrequencyObservable<number>;
+export const onEverySecond$ = (() => timer(0, 1000)) as FrequencyObservable<
+  number
+>;
 onEverySecond$.metadata = { name: 'onEverySecond$' };
 
 /**
  * Observable that emits on every other second.
  */
-export const onEvery2Seconds$ = timer(0, 2000) as FrequencyObservable<number>;
+export const onEvery2Seconds$ = (() => timer(0, 2000)) as FrequencyObservable<
+  number
+>;
 onEvery2Seconds$.metadata = { name: 'onEvery2Seconds$' };
 
 /**
  * Observable that emits every five seconds.
  */
-export const onEvery5Seconds$ = timer(0, 5000) as FrequencyObservable<number>;
+export const onEvery5Seconds$ = (() => timer(0, 5000)) as FrequencyObservable<
+  number
+>;
 onEvery5Seconds$.metadata = { name: 'onEvery5Seconds$' };

--- a/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
+++ b/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
@@ -3,32 +3,32 @@
 //
 // SPDX-License-Identifier: MIT
 
-import createOnFromPubsub from './createOnFromPubsub';
+import createPubsubObservable from './createPubsubObservable';
 import isObservable from '../../utils/isObservable';
 import { rejectApi, resolveApi } from '../../utils/testHelpers/mockApi';
 
 it('should return an Observable', () => {
-  expect(isObservable(createOnFromPubsub('fake_method', resolveApi))).toBe(
+  expect(isObservable(createPubsubObservable('fake_method', resolveApi))).toBe(
     true
   );
 });
 
 it('should fire an event when pubsub publishes', done => {
-  createOnFromPubsub('fake_method', resolveApi).subscribe(data => {
+  createPubsubObservable('fake_method', resolveApi).subscribe(data => {
     expect(data).toBe('foo');
     done();
   });
 });
 
 it('should fire an error when pubsub errors', done => {
-  createOnFromPubsub('fake_method', rejectApi).subscribe(null, err => {
+  createPubsubObservable('fake_method', rejectApi).subscribe(null, err => {
     expect(err).toEqual(new Error('bar'));
     done();
   });
 });
 
 it('should fire an event when polling pubsub  publishes', done => {
-  createOnFromPubsub('fake_method', () =>
+  createPubsubObservable('fake_method', () =>
     resolveApi(undefined, false)
   ).subscribe(data => {
     expect(data).toBe('foo');
@@ -37,7 +37,7 @@ it('should fire an event when polling pubsub  publishes', done => {
 });
 
 it('should fire an error when polling pubsub errors', done => {
-  createOnFromPubsub('fake_method', () =>
+  createPubsubObservable('fake_method', () =>
     rejectApi(undefined, false)
   ).subscribe(null, err => {
     expect(err).toEqual(new Error('bar'));

--- a/packages/light.js/src/rpc/utils/createRpc.spec.ts
+++ b/packages/light.js/src/rpc/utils/createRpc.spec.ts
@@ -26,7 +26,7 @@ it('should contain frequencyMixins', () => {
 });
 
 it('should set correct frequency', () => {
-  const frequency = timer(0, 1000);
+  const frequency = () => timer(0, 1000);
   const rpc$ = createRpc({});
   rpc$.setFrequency([frequency]);
   expect(rpc$.metadata.frequency).toEqual([frequency]);

--- a/packages/light.js/src/types.ts
+++ b/packages/light.js/src/types.ts
@@ -34,7 +34,8 @@ export interface Metadata<Source, Out> {
   pipes?: (...args: any[]) => OperatorFunction<Source, Out>[];
 }
 
-export interface FrequencyObservable<T> extends Observable<T> {
+export interface FrequencyObservable<T> {
+  (): Observable<T>;
   metadata?: { calls?: string[]; name: string };
 }
 

--- a/packages/light.js/src/utils/testHelpers/mockRpc.ts
+++ b/packages/light.js/src/utils/testHelpers/mockRpc.ts
@@ -12,6 +12,6 @@ import createRpc from '../../rpc/utils/createRpc';
  *
  * @ignore
  */
-const mockRpc$ = createRpc({ frequency: [timer(0, 1000)] });
+const mockRpc$ = createRpc({ frequency: [() => timer(0, 1000)] });
 
 export default mockRpc$;

--- a/packages/light.js/src/utils/testHelpers/testFrequency.ts
+++ b/packages/light.js/src/utils/testHelpers/testFrequency.ts
@@ -14,11 +14,11 @@ import isObservable from '../isObservable';
 const testFrequency = (name: string, frequency$: FrequencyObservable<any>) =>
   describe(`${name} rpc`, () => {
     it('should be an Observable', () => {
-      expect(isObservable(frequency$)).toBe(true);
+      expect(isObservable(frequency$())).toBe(true);
     });
 
     it('should be subscribable', () => {
-      expect(() => frequency$.subscribe()).not.toThrow();
+      expect(() => frequency$().subscribe()).not.toThrow();
     });
 
     it('should contain a `metadata` field', () => {


### PR DESCRIPTION
**Before:**

At startup, NullProvider is used, and because of [this](https://github.com/paritytech/js-libs/blob/master/packages/light.js/src/frequency/utils/createOnFromPubsub.ts#L28-L39), `onEveryBlock$` is a `timer(0,1000)`.

After that, we set the real provider. However at that point the frequency of e.g. `balanceOf$` is `onEveryBlock$ == timer(0,1000)`.

**After this PR:**

Make `onEveryBlock$` (and all other FrequencyObservables) a function returning an Observable.

When we call `balanceOf$()`, it will only then call `onEveryBlock$()`, which will itself only then call `api()`, and `api` is already set by then. Also, when the api provider is still NullProvider, `balanceOf$` is not memoized, so calling `balanceOf$()` will always recall `onEveryBlock$()` and `api()`.

**To test:**

In the [example/ folder](https://github.com/paritytech/js-libs/tree/master/packages/light.js/example), replace in `index.js`:

```diff
-light.setProvider(provider);
+setTimeout(() => {
+  console.log('Set provider');
+  light.setProvider(provider);
+}, 5000);
```

For this 5 first seconds, the NullProvider should output the debug logs, then you should see result.

**Things to improve:**
If we:

```javascript
light.setProvider(provider1);

balanceOf$(...);
// do something else

light.setProvider(provider2);
```

After the 2nd setProvider, `balanceOf$` will still use the 1st provider, because of memoization.

**Notes:**
- Fixes https://github.com/paritytech/fether/issues/197