### PR TITLE
Fix default options in @parity/electron

### DIFF
--- a/packages/electron/docs/README.md
+++ b/packages/electron/docs/README.md
@@ -65,7 +65,7 @@ isParityRunning()
 
 ▸ **checkClockSync**(): `Promise`<[CheckClockSyncResult](docs/interfaces/checkclocksyncresult.md)>
 
-_Defined in [checkClockSync.ts:21](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/checkClockSync.ts#L21)_
+_Defined in [checkClockSync.ts:21](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/checkClockSync.ts#L21)_
 
 Use SNTP to check if the local clock is synchronized; return the time drift.
 
@@ -79,7 +79,7 @@ Use SNTP to check if the local clock is synchronized; return the time drift.
 
 ▸ **defaultParityPath**(): `Promise`<`string`>
 
-_Defined in [getParityPath.ts:23](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/getParityPath.ts#L23)_
+_Defined in [getParityPath.ts:23](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/getParityPath.ts#L23)_
 
 The default path to install parity, in case there's no other instance found on the machine.
 
@@ -93,7 +93,7 @@ The default path to install parity, in case there's no other instance found on t
 
 ▸ **deleteParity**(): `Promise`<`void`>
 
-_Defined in [fetchParity.ts:84](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/fetchParity.ts#L84)_
+_Defined in [fetchParity.ts:84](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/fetchParity.ts#L84)_
 
 Remove parity binary or partial binary in the userData folder, if it exists.
 
@@ -107,7 +107,7 @@ Remove parity binary or partial binary in the userData folder, if it exists.
 
 ▸ **fetchParity**(mainWindow: _`BrowserWindow`_, options?: _[FetchParityOptions](docs/interfaces/fetchparityoptions.md)_): `Promise`<`string`>
 
-_Defined in [fetchParity.ts:106](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/fetchParity.ts#L106)_
+_Defined in [fetchParity.ts:106](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/fetchParity.ts#L106)_
 
 Downloads Parity, saves it to Electron's `userData` folder, and returns the path to the downloaded binary once finished.
 
@@ -128,7 +128,7 @@ Downloads Parity, saves it to Electron's `userData` folder, and returns the path
 
 ▸ **getParityPath**(): `Promise`<`string`>
 
-_Defined in [getParityPath.ts:119](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/getParityPath.ts#L119)_
+_Defined in [getParityPath.ts:104](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/getParityPath.ts#L104)_
 
 Returns the path to Parity, or throws if parity is not found.
 
@@ -142,7 +142,7 @@ Returns the path to Parity, or throws if parity is not found.
 
 ▸ **isParityRunning**(options?: _[IsParityRunningOptions](docs/interfaces/isparityrunningoptions.md)_): `Promise`<`boolean`>
 
-_Defined in [isParityRunning.ts:20](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/isParityRunning.ts#L20)_
+_Defined in [isParityRunning.ts:20](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/isParityRunning.ts#L20)_
 
 Detect if another instance of parity is already running or not. To achieve that, we just ping on the common hosts.
 
@@ -162,7 +162,7 @@ Detect if another instance of parity is already running or not. To achieve that,
 
 ▸ **killParity**(): `Promise`<`void`>
 
-_Defined in [runParity.ts:112](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/runParity.ts#L112)_
+_Defined in [runParity.ts:118](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/runParity.ts#L118)_
 
 If a Parity process has been spawned with runParity, then it kills this process. However, there's no guarantee that Parity has been cleanly killed, and the Promise resolves instantly.
 
@@ -176,7 +176,7 @@ If a Parity process has been spawned with runParity, then it kills this process.
 
 ▸ **parityElectron**(options?: _[ParityElectronOptions](docs/interfaces/parityelectronoptions.md)_): `void`
 
-_Defined in [index.ts:25](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/index.ts#L25)_
+_Defined in [index.ts:25](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/index.ts#L25)_
 
 Set default options for @parity/electron. Can be skipped if we don't want to override default options.
 
@@ -196,7 +196,7 @@ Set default options for @parity/electron. Can be skipped if we don't want to ove
 
 ▸ **runParity**(options?: _[RunParityOptions](docs/interfaces/runparityoptions.md)_): `Promise`<`void`>
 
-_Defined in [runParity.ts:44](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/runParity.ts#L44)_
+_Defined in [runParity.ts:44](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/runParity.ts#L44)_
 
 Spawns a child process to run Parity.
 
@@ -216,7 +216,7 @@ Spawns a child process to run Parity.
 
 ▸ **signerNewToken**(): `Promise`<`string`>
 
-_Defined in [signerNewToken.ts:16](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/signerNewToken.ts#L16)_
+_Defined in [signerNewToken.ts:16](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/signerNewToken.ts#L16)_
 
 Runs parity signer new-token and resolves with a new secure token to be used in a dapp. Rejects if no token could be extracted.
 

--- a/packages/electron/docs/interfaces/checkclocksyncresult.md
+++ b/packages/electron/docs/interfaces/checkclocksyncresult.md
@@ -23,7 +23,7 @@
 
 **● isClockSync**: *`boolean`*
 
-*Defined in [checkClockSync.ts:9](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/checkClockSync.ts#L9)*
+*Defined in [checkClockSync.ts:9](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/checkClockSync.ts#L9)*
 
 ___
 <a id="timedrift"></a>
@@ -32,7 +32,7 @@ ___
 
 **● timeDrift**: *`number`*
 
-*Defined in [checkClockSync.ts:10](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/checkClockSync.ts#L10)*
+*Defined in [checkClockSync.ts:10](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/checkClockSync.ts#L10)*
 
 ___
 

--- a/packages/electron/docs/interfaces/fetchparityoptions.md
+++ b/packages/electron/docs/interfaces/fetchparityoptions.md
@@ -23,7 +23,7 @@
 
 **● onProgress**: *`function`*
 
-*Defined in [fetchParity.ts:18](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/fetchParity.ts#L18)*
+*Defined in [fetchParity.ts:18](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/fetchParity.ts#L18)*
 
 #### Type declaration
 ▸(progress: *`number`*): `void`
@@ -43,7 +43,7 @@ ___
 
 **● parityChannel**: *`string`*
 
-*Defined in [fetchParity.ts:19](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/fetchParity.ts#L19)*
+*Defined in [fetchParity.ts:19](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/fetchParity.ts#L19)*
 
 ___
 

--- a/packages/electron/docs/interfaces/isparityrunningoptions.md
+++ b/packages/electron/docs/interfaces/isparityrunningoptions.md
@@ -23,7 +23,7 @@
 
 **● wsInterface**: *`string`*
 
-*Defined in [isParityRunning.ts:12](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/isParityRunning.ts#L12)*
+*Defined in [isParityRunning.ts:12](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/isParityRunning.ts#L12)*
 
 ___
 <a id="wsport"></a>
@@ -33,7 +33,7 @@ ___
 **● wsPort**: * `number` &#124; `string`
 *
 
-*Defined in [isParityRunning.ts:13](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/isParityRunning.ts#L13)*
+*Defined in [isParityRunning.ts:13](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/isParityRunning.ts#L13)*
 
 ___
 

--- a/packages/electron/docs/interfaces/parityelectronoptions.md
+++ b/packages/electron/docs/interfaces/parityelectronoptions.md
@@ -22,7 +22,7 @@
 
 **● logger**: *`LoggerFunction`*
 
-*Defined in [index.ts:18](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/index.ts#L18)*
+*Defined in [index.ts:18](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/index.ts#L18)*
 
 ___
 

--- a/packages/electron/docs/interfaces/runparityoptions.md
+++ b/packages/electron/docs/interfaces/runparityoptions.md
@@ -23,7 +23,7 @@
 
 **● flags**: *`string`[]*
 
-*Defined in [runParity.ts:15](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/runParity.ts#L15)*
+*Defined in [runParity.ts:15](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/runParity.ts#L15)*
 
 ___
 <a id="onparityerror"></a>
@@ -32,7 +32,7 @@ ___
 
 **● onParityError**: *`function`*
 
-*Defined in [runParity.ts:16](https://github.com/paritytech/js-libs/blob/f3c5e36/packages/electron/src/runParity.ts#L16)*
+*Defined in [runParity.ts:16](https://github.com/paritytech/js-libs/blob/6933cc7/packages/electron/src/runParity.ts#L16)*
 
 #### Type declaration
 ▸(error: *`Error`*): `void`

--- a/packages/electron/src/fetchParity.ts
+++ b/packages/electron/src/fetchParity.ts
@@ -112,7 +112,14 @@ export async function fetchParity(
     parityChannel: 'beta'
   }
 ) {
-  const { onProgress, parityChannel } = options;
+  const { onProgress, parityChannel } = {
+    onProgress: () => {
+      /* Do nothing by defaut. */
+    },
+    parityChannel: 'beta',
+    ...options
+  };
+
   try {
     const parityPath = retry(
       async (_, attempt: number) => {

--- a/packages/electron/src/getParityPath.ts
+++ b/packages/electron/src/getParityPath.ts
@@ -90,28 +90,13 @@ const isParityInUserData = async () => {
  * @ignore
  * @return Promise<string> - Resolves to a string which is the command to run parity.
  */
-const doesParityExist = async () => {
-  try {
-    // First test if `parity` command exists
-    return await isParityInPath();
-  } catch (e) {
-    /* Do nothing if error. */
-  }
-
-  try {
-    // Then test if parity is in OS
-    return await isParityInOs();
-  } catch (e) {
-    /* Do nothing if error. */
-  }
-
-  try {
-    // Finally test userData folder
-    return await isParityInUserData();
-  } catch (e) {
-    throw new Error('Parity not found.');
-  }
-};
+const doesParityExist = () =>
+  isParityInPath()
+    .catch(isParityInOs)
+    .catch(isParityInUserData)
+    .catch(_ => {
+      throw new Error('Parity not found.');
+    });
 
 /**
  * Returns the path to Parity, or throws if parity is not found.

--- a/packages/electron/src/isParityRunning.ts
+++ b/packages/electron/src/isParityRunning.ts
@@ -23,7 +23,12 @@ export async function isParityRunning(
     wsPort: '8546'
   }
 ) {
-  const { wsInterface, wsPort } = options;
+  const { wsInterface, wsPort } = {
+    wsInterface: '127.0.0.1',
+    wsPort: '8546',
+    ...options
+  };
+
   /**
    * Try to ping these hosts to test if Parity is running.
    */

--- a/packages/electron/src/runParity.ts
+++ b/packages/electron/src/runParity.ts
@@ -49,7 +49,13 @@ export async function runParity(
     }
   }
 ) {
-  const { flags, onParityError } = options;
+  const { flags, onParityError } = {
+    flags: [],
+    onParityError: () => {
+      /* Do nothing if error. */
+    },
+    ...options
+  };
   const parityPath = await getParityPath();
 
   // Some users somehow had no +x on the parity binary after downloading


### PR DESCRIPTION
I'm not really satisfied, because we define 2 times each default option. But unfortunately because of https://github.com/TypeStrong/typedoc/issues/522, it's either nice code or nice docs. I went for nice docs.