### PR TITLE
Fix eth_getTransactionReceipt throwing error

### DIFF
--- a/packages/light.js/package.json
+++ b/packages/light.js/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@parity/abi": "^2.1.4",
     "@parity/api": "^2.1.23",
+    "async-retry": "^1.2.3",
     "bignumber.js": "^7.2.1",
     "debug": "^3.1.0",
     "memoizee": "^0.4.12"

--- a/packages/light.js/src/rpc/other/post.ts
+++ b/packages/light.js/src/rpc/other/post.ts
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+import * as asyncRetry from 'async-retry';
+import * as debug from 'debug';
 import { Observable, Observer } from 'rxjs';
 
 import { createApiFromProvider, getApi } from '../../api';
@@ -44,13 +46,24 @@ export function post$(tx: Tx, options: PostOptions = {}) {
         observer.next({ signed: transactionHash, schedule: tx.condition });
       } else {
         observer.next({ signed: transactionHash });
-        const receipt = await api.pollMethod(
-          'eth_getTransactionReceipt',
-          transactionHash,
-          (
-            receipt: any // TODO Receipt use @parity/api type
-          ) => receipt && receipt.blockNumber && !receipt.blockNumber.eq(0)
+
+        // We poll `eth_getTransactionReceipt` for 20s, until we get a valid receipt
+        const receipt = await asyncRetry(
+          async (_, attempt) => {
+            debug('@parity/light.js:api')(
+              `Attempt #${attempt} to eth_getTransactionReceipt.`
+            );
+            const rcpt = await api.eth.getTransactionReceipt(transactionHash);
+            if (!rcpt || !rcpt.blockNumber || rcpt.blockNumber.eq(0)) {
+              throw new Error('Receipt is invalid.');
+            }
+            return rcpt;
+          },
+          {
+            retries: 20
+          }
         );
+
         observer.next({ confirmed: receipt });
       }
 

--- a/packages/light.js/src/rpc/other/post.ts
+++ b/packages/light.js/src/rpc/other/post.ts
@@ -50,7 +50,7 @@ export function post$(tx: Tx, options: PostOptions = {}) {
         // We poll `eth_getTransactionReceipt` for 20s, until we get a valid receipt
         const receipt = await asyncRetry(
           async (_, attempt) => {
-            debug('@parity/light.js:api')(
+            debug('@parity/light.js:post$')(
               `Attempt #${attempt} to eth_getTransactionReceipt.`
             );
             const rcpt = await api.eth.getTransactionReceipt(transactionHash);

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,6 +379,12 @@ async-retry@^1.2.1:
   dependencies:
     retry "0.10.1"
 
+async-retry@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
+  dependencies:
+    retry "0.12.0"
+
 async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -4378,6 +4384,10 @@ ret@~0.1.10:
 retry@0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+
+retry@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
 
 right-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
On parity-ethereum, `api.pollMethod('eth_getTransactionReceipt')` didn't throw if there was no receipt yet. Now it throws.

So we manually poll/catch for 20s. 