### PR TITLE
Fix bug contract functions were memoized

### DIFF
--- a/packages/light.js/package.json
+++ b/packages/light.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parity/light.js",
   "description": "A high-level reactive JS library optimized for light clients",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Parity Team <admin@parity.io>",
   "license": "MIT",
   "repository": "https://github.com/paritytech/js-libs/tree/master/packages/light.js",

--- a/packages/light.js/package.json
+++ b/packages/light.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parity/light.js",
   "description": "A high-level reactive JS library optimized for light clients",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Parity Team <admin@parity.io>",
   "license": "MIT",
   "repository": "https://github.com/paritytech/js-libs/tree/master/packages/light.js",

--- a/packages/light.js/src/rpc/other/makeContract.ts
+++ b/packages/light.js/src/rpc/other/makeContract.ts
@@ -81,7 +81,7 @@ const makeContractWithApi = memoizee(
         if (method.constant) {
           return createRpc({
             frequency: [frequency.onEveryBlock$],
-            name,
+            name: `${address}:${name}`,
             pipes: () => [
               switchMapPromise(() =>
                 contract.instance[name].call(options, args)


### PR DESCRIPTION
Let's say I created 2 erc20 with `makeContract$`, they both have the `transfer` function. So the `transfer$` (which is a `createRpc)` takes into the same metadata, so is memoized.

We now change the metadata so that it includes the address, and 2 contracts' same function won't be memoized as one.