### PR TITLE
misc: Move types. Renaming/typos in comments. Fix linting errors. Add license headers. Add FIXMEs

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -77,7 +77,7 @@ contract.instance.callMe
 
 ## apis
 
-APIs implement the calls as exposed in the [Ethcore JSON Ethereum RPC](https://github.com/paritytech/js-api) definitions. Mapping follows the naming conventions of the originals, i.e. `eth_call` becomes `eth.call`, `personal_accounts` becomes `personal.accounts`, etc.
+APIs implement the calls as exposed in the [Parity JSON Ethereum RPC](https://github.com/paritytech/js-api) definitions. Mapping follows the naming conventions of the originals, i.e. `eth_call` becomes `eth.call`, `personal_accounts` becomes `personal.accounts`, etc.
 
 ## public node
 

--- a/packages/api/src/api.js
+++ b/packages/api/src/api.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/api.spec.js
+++ b/packages/api/src/api.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/contract/contract.js
+++ b/packages/api/src/contract/contract.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/contract/contract.spec.js
+++ b/packages/api/src/contract/contract.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/contract/index.js
+++ b/packages/api/src/contract/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/format/input.spec.js
+++ b/packages/api/src/format/input.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/format/output.js
+++ b/packages/api/src/format/output.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/format/output.spec.js
+++ b/packages/api/src/format/output.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/library.js
+++ b/packages/api/src/library.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/current.js
+++ b/packages/api/src/provider/current.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/current.spec.js
+++ b/packages/api/src/provider/current.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/http.js
+++ b/packages/api/src/provider/http.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/http.spec.js
+++ b/packages/api/src/provider/http.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/index.js
+++ b/packages/api/src/provider/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/ipc.js
+++ b/packages/api/src/provider/ipc.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -72,7 +72,7 @@ class Ipc extends EventEmitter {
 
   requestNewToken () {
     return new Promise((resolve, reject) => {
-      // Webview is ready when receivin the ping
+      // Webview is ready when receiving the ping
       ipcRenderer.once('ping', () => {
         this.send(METHOD_REQUEST_TOKEN, [], (error, token) => {
           if (error) {

--- a/packages/api/src/provider/ipc.spec.js
+++ b/packages/api/src/provider/ipc.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/postMessage.spec.js
+++ b/packages/api/src/provider/postMessage.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/promise.js
+++ b/packages/api/src/provider/promise.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/sendAsync.js
+++ b/packages/api/src/provider/sendAsync.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/sendAsync.spec.js
+++ b/packages/api/src/provider/sendAsync.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/ws.js
+++ b/packages/api/src/provider/ws.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/provider/ws.spec.js
+++ b/packages/api/src/provider/ws.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/eth/eth.js
+++ b/packages/api/src/pubsub/eth/eth.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/eth/index.js
+++ b/packages/api/src/pubsub/eth/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/index.js
+++ b/packages/api/src/pubsub/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/net/index.js
+++ b/packages/api/src/pubsub/net/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/net/net.js
+++ b/packages/api/src/pubsub/net/net.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/parity/index.js
+++ b/packages/api/src/pubsub/parity/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/parity/parity.js
+++ b/packages/api/src/pubsub/parity/parity.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/pubsub.js
+++ b/packages/api/src/pubsub/pubsub.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/pubsub.spec.js
+++ b/packages/api/src/pubsub/pubsub.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/pubsubBase.js
+++ b/packages/api/src/pubsub/pubsubBase.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 class PubSubBase {
-  // Provider for websocket pubsub transport
+  // Provider for Websocket pub-sub transport
   constructor (provider) {
     this._provider = provider;
   }

--- a/packages/api/src/pubsub/signer/index.js
+++ b/packages/api/src/pubsub/signer/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/pubsub/signer/signer.js
+++ b/packages/api/src/pubsub/signer/signer.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/db/db.js
+++ b/packages/api/src/rpc/db/db.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/db/db.spec.js
+++ b/packages/api/src/rpc/db/db.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/db/index.js
+++ b/packages/api/src/rpc/db/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/eth/eth.e2e.js
+++ b/packages/api/src/rpc/eth/eth.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/eth/eth.js
+++ b/packages/api/src/rpc/eth/eth.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/eth/eth.spec.js
+++ b/packages/api/src/rpc/eth/eth.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/eth/index.js
+++ b/packages/api/src/rpc/eth/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/index.js
+++ b/packages/api/src/rpc/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/net/index.js
+++ b/packages/api/src/rpc/net/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/net/net.e2e.js
+++ b/packages/api/src/rpc/net/net.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/net/net.js
+++ b/packages/api/src/rpc/net/net.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/net/net.spec.js
+++ b/packages/api/src/rpc/net/net.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/parity/index.js
+++ b/packages/api/src/rpc/parity/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/parity/parity.e2e.js
+++ b/packages/api/src/rpc/parity/parity.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -16,6 +16,7 @@
 
 /* eslint-disable no-unused-expressions */
 
+// FIXME - where is this file '../../test/e2e/ethapi'
 const { createHttpApi } = require('../../test/e2e/ethapi');
 
 describe('ethapi.parity', () => {
@@ -48,6 +49,7 @@ describe('ethapi.parity', () => {
   });
 
   describe('netChain', () => {
+    // FIXME - should this be 'returns and translates the chain'
     it('returns and the chain', () => {
       return ethapi.parity.netChain().then((value) => {
         expect(value).toEqual('morden');

--- a/packages/api/src/rpc/parity/parity.js
+++ b/packages/api/src/rpc/parity/parity.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/parity/parity.spec.js
+++ b/packages/api/src/rpc/parity/parity.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/personal/index.js
+++ b/packages/api/src/rpc/personal/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/personal/personal.e2e.js
+++ b/packages/api/src/rpc/personal/personal.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/personal/personal.js
+++ b/packages/api/src/rpc/personal/personal.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/personal/personal.spec.js
+++ b/packages/api/src/rpc/personal/personal.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/private/index.js
+++ b/packages/api/src/rpc/private/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/private/private.js
+++ b/packages/api/src/rpc/private/private.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/shell/index.js
+++ b/packages/api/src/rpc/shell/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/shell/shell.js
+++ b/packages/api/src/rpc/shell/shell.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/shh/index.js
+++ b/packages/api/src/rpc/shh/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/shh/shh.js
+++ b/packages/api/src/rpc/shh/shh.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/signer/index.js
+++ b/packages/api/src/rpc/signer/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/signer/signer.js
+++ b/packages/api/src/rpc/signer/signer.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/trace/index.js
+++ b/packages/api/src/rpc/trace/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/trace/trace.e2e.js
+++ b/packages/api/src/rpc/trace/trace.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/trace/trace.js
+++ b/packages/api/src/rpc/trace/trace.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/trace/trace.spec.js
+++ b/packages/api/src/rpc/trace/trace.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/web3/index.js
+++ b/packages/api/src/rpc/web3/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/web3/web3.e2e.js
+++ b/packages/api/src/rpc/web3/web3.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/web3/web3.js
+++ b/packages/api/src/rpc/web3/web3.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/rpc/web3/web3.spec.js
+++ b/packages/api/src/rpc/web3/web3.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/eth.js
+++ b/packages/api/src/subscriptions/eth.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/eth.spec.js
+++ b/packages/api/src/subscriptions/eth.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/index.js
+++ b/packages/api/src/subscriptions/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/logging.js
+++ b/packages/api/src/subscriptions/logging.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/logging.spec.js
+++ b/packages/api/src/subscriptions/logging.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/manager.js
+++ b/packages/api/src/subscriptions/manager.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -46,7 +46,7 @@ class Manager {
       };
     });
 
-    // in the case of a pubsub compliant, don't use the engines
+    // in the case of a pub-sub compliant, don't use the engines
     if (this._api.isPubSub) {
       return;
     }

--- a/packages/api/src/subscriptions/manager.spec.js
+++ b/packages/api/src/subscriptions/manager.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/personal.js
+++ b/packages/api/src/subscriptions/personal.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/personal.spec.js
+++ b/packages/api/src/subscriptions/personal.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/subscriptions/signer.js
+++ b/packages/api/src/subscriptions/signer.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/TransportError.ts
+++ b/packages/api/src/transport/TransportError.ts
@@ -42,7 +42,7 @@ class TransportError extends Error {
    */
   public method: string;
   /**
-   * The message of the
+   * The message of the RPC call.
    */
   public text: string;
   /**

--- a/packages/api/src/transport/http/http.e2e.js
+++ b/packages/api/src/transport/http/http.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/http/http.js
+++ b/packages/api/src/transport/http/http.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/http/http.spec.js
+++ b/packages/api/src/transport/http/http.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/http/index.js
+++ b/packages/api/src/transport/http/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/index.js
+++ b/packages/api/src/transport/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/jsonRpcBase.js
+++ b/packages/api/src/transport/jsonRpcBase.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/jsonRpcBase.spec.js
+++ b/packages/api/src/transport/jsonRpcBase.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -36,7 +36,7 @@ describe('transport/JsonRpcBase', () => {
       });
     });
 
-    it('intialises Middleware added', (done) => {
+    it('initialises Middleware added', (done) => {
       const base2 = new JsonRpcBase();
 
       class Middleware {

--- a/packages/api/src/transport/jsonRpcEncoder.js
+++ b/packages/api/src/transport/jsonRpcEncoder.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/jsonRpcEncoder.spec.js
+++ b/packages/api/src/transport/jsonRpcEncoder.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/middleware.js
+++ b/packages/api/src/transport/middleware.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/middleware.spec.js
+++ b/packages/api/src/transport/middleware.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/ws/index.js
+++ b/packages/api/src/transport/ws/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/ws/polyfill.js
+++ b/packages/api/src/transport/ws/polyfill.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/ws/ws.e2e.js
+++ b/packages/api/src/transport/ws/ws.e2e.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/transport/ws/ws.js
+++ b/packages/api/src/transport/ws/ws.js
@@ -92,7 +92,7 @@ class Ws extends JsonRpcBase {
     this._connected = false;
     this._lastError = null;
 
-    // rpc secure API
+    // RPC secure API
     if (this._token) {
       const time = parseInt(new Date().getTime() / 1000, 10);
       const sha3 = keccak_256(`${this._token}:${time}`);
@@ -215,7 +215,7 @@ class Ws extends JsonRpcBase {
     const { result: res, id, method, params } = result;
     const msg = this._messages[id];
 
-    // initial pubsub ACK
+    // initial pub-sub ACK
     if (id && msg.subscription) {
       // save subscription to map subId -> messageId
       this._subscriptions[msg.subscription] = this._subscriptions[msg.subscription] || {};
@@ -232,7 +232,7 @@ class Ws extends JsonRpcBase {
       return msg;
     }
 
-    // pubsub format
+    // pub-sub format
     if (this._subscriptions[method]) {
       const messageId = this._messages[this._subscriptions[method][params.subscription]];
 

--- a/packages/api/src/transport/ws/ws.spec.js
+++ b/packages/api/src/transport/ws/ws.spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/src/types.d.ts
+++ b/packages/api/src/types.d.ts
@@ -5,6 +5,8 @@
 
 import BigNumber from 'bignumber.js';
 
+export type Api = any;
+
 export type Bytes = number[];
 
 export type BlockNumber =
@@ -13,6 +15,12 @@ export type BlockNumber =
   | 'pending'
   | number
   | BigNumber;
+
+export type ContractInstance = any;
+
+export interface Contract {
+  instance: ContractInstance;
+}
 
 export type EtherDenomination =
   | 'wei'
@@ -26,3 +34,25 @@ export type EtherDenomination =
   | 'mether'
   | 'gether'
   | 'tether';
+
+export type InputDeriveHashMap = {
+  [key: string]: string | number
+}
+
+export type BlockInfo = {
+  [key: string]: BlockNumber | Date | null
+}
+
+export type InputOptionsConditions = {
+  [key: string]: BlockInfo | number
+}
+
+export type InputOptions = {
+  [key: string]: Array<string | number | BlockNumber> | InputOptionsConditions | string | number | BlockNumber
+}
+
+export type InputTrace = Array<string> | string;
+
+export type InputTraceHashMap = {
+  [key: string]: BlockNumber | string | Array<string>;
+}

--- a/packages/api/src/util/encode.ts
+++ b/packages/api/src/util/encode.ts
@@ -61,7 +61,7 @@ export const abiEncode = (
 /**
  * Unencode a method.
  *
- * @param abi - The Abi to unencode.
+ * @param abi - The ABI to unencode.
  * @param data - The data passed to this method.
  */
 export const abiUnencode = (abi: AbiObject, data: string) => {
@@ -98,7 +98,7 @@ export const abiUnencode = (abi: AbiObject, data: string) => {
 };
 
 /**
- * Get the signature of an Abi method.
+ * Get the signature of an ABI method.
  *
  * @param name - The name of the method.
  * @param inputs - The inputs' types of this method.

--- a/packages/api/src/util/wei.ts
+++ b/packages/api/src/util/wei.ts
@@ -22,9 +22,9 @@ const UNITS: EtherDenomination[] = [
 ];
 
 /**
- * Returns the multiplication factor from wei to another ether denomination.
+ * Returns the multiplication factor from wei to another Ether denomination.
  *
- * @param unit - An ether denomiation.
+ * @param unit - An Ether denomination.
  * @example
  * _getUnitMultiplier('wei'); // 1
  * _getUnitMultiplier('ether'); // 10^^18
@@ -41,10 +41,10 @@ export const _getUnitMultiplier = (unit: EtherDenomination) => {
 };
 
 /**
- * Convert from wei to another ether denomination.
+ * Convert from wei to another Ether denomination.
  *
  * @param value - The value in wei.
- * @param unit - The ether denomination to convert to.
+ * @param unit - The Ether denomination to convert to.
  */
 export const fromWei = (
   value: string | number | BigNumber,
@@ -52,10 +52,10 @@ export const fromWei = (
 ) => new BigNumber(value).dividedBy(_getUnitMultiplier(unit));
 
 /**
- * Convert a value from an ether denomination to wei.
+ * Convert a value from an Ether denomination to wei.
  *
- * @param value - The value in the ether denomination.
- * @param unit - The ether denomination to convert to.
+ * @param value - The value in the Ether denomination.
+ * @param unit - The Ether denomination to convert to.
  */
 export const toWei = (
   value: string | number | BigNumber,

--- a/packages/api/test/mocha.config.js
+++ b/packages/api/test/mocha.config.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/test/mockRpc.js
+++ b/packages/api/test/mockRpc.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/api/test/types.js
+++ b/packages/api/test/types.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/contracts/src/abi/index.ts
+++ b/packages/contracts/src/abi/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/packages/contracts/src/badgereg.ts
+++ b/packages/contracts/src/badgereg.ts
@@ -7,7 +7,7 @@ import BigNumber from 'bignumber.js';
 import { bytesToHex, hexToAscii } from '@parity/api/lib/util/format';
 
 import * as ABI from './abi/certifier.json';
-import { Api, Contract } from './types';
+import { Api, Contract } from '@parity/api/src/types';
 import Registry from './registry';
 
 interface Metadata {

--- a/packages/contracts/src/contracts.ts
+++ b/packages/contracts/src/contracts.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api } from './types';
+import { Api } from '@parity/api/src/types';
 import DappReg from './dappreg';
 import Registry from './registry';
 import SignatureReg from './signaturereg';

--- a/packages/contracts/src/dappreg.ts
+++ b/packages/contracts/src/dappreg.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api, Contract, ContractInstance } from './types';
+import { Api, Contract, ContractInstance } from '@parity/api/src/types';
 import Registry from './registry';
 
 export default class DappReg {

--- a/packages/contracts/src/githubhint.spec.ts
+++ b/packages/contracts/src/githubhint.spec.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { ContractInstance } from './types';
+import { ContractInstance } from '@parity/api/src/types';
 import GithubHint from './githubhint';
 import mockApi from './utils/testHelpers';
 import Registry from './registry';

--- a/packages/contracts/src/githubhint.ts
+++ b/packages/contracts/src/githubhint.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api, Contract, ContractInstance } from './types';
+import { Api, Contract, ContractInstance } from '@parity/api/src/types';
 import Registry from './registry';
 
 export default class GithubHint {

--- a/packages/contracts/src/registry.spec.ts
+++ b/packages/contracts/src/registry.spec.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api, ContractInstance } from './types';
+import { Api, ContractInstance } from '@parity/api/src/types';
 import mockApi from './utils/testHelpers';
 import Registry from './registry';
 

--- a/packages/contracts/src/registry.ts
+++ b/packages/contracts/src/registry.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import * as abis from './abi';
-import { Api, Contract, ContractInstance } from './types';
+import { Api, Contract, ContractInstance } from '@parity/api/src/types';
 
 interface QueueItem {
   resolve(...args: any[]): void;

--- a/packages/contracts/src/signaturereg.ts
+++ b/packages/contracts/src/signaturereg.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api, ContractInstance } from './types';
+import { Api, ContractInstance } from '@parity/api/src/types';
 import Registry from './registry';
 
 export default class SignatureReg {

--- a/packages/contracts/src/tokenreg.ts
+++ b/packages/contracts/src/tokenreg.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Api, Contract, ContractInstance } from './types';
+import { Api, Contract, ContractInstance } from '@parity/api/src/types';
 import Registry from './registry';
 
 export default class TokenReg {

--- a/packages/contracts/src/types.d.ts
+++ b/packages/contracts/src/types.d.ts
@@ -1,6 +1,0 @@
-// TODO Take from @parity/api
-export type Api = any;
-export type ContractInstance = any;
-export interface Contract {
-  instance: ContractInstance;
-}

--- a/packages/contracts/src/utils/testHelpers.ts
+++ b/packages/contracts/src/utils/testHelpers.ts
@@ -5,7 +5,7 @@
 
 import * as apiutil from '@parity/api/lib/util';
 
-import { ContractInstance } from '../types';
+import { ContractInstance } from '@parity/api/src/types';
 
 /**
  * @ignore

--- a/packages/electron/src/README.md
+++ b/packages/electron/src/README.md
@@ -1,6 +1,6 @@
 # @parity/electron
 
-Control the Parity Ethereum client from electron.
+Control the Parity Ethereum client from Electron.
 
 [![Build Status](https://travis-ci.org/paritytech/js-libs.svg?branch=master)](https://travis-ci.org/paritytech/js-libs)
 [![npm (scoped)](https://img.shields.io/npm/v/@parity/electron.svg)](https://www.npmjs.com/package/@parity/electron)

--- a/packages/electron/src/fetchParity.ts
+++ b/packages/electron/src/fetchParity.ts
@@ -79,19 +79,19 @@ const getOs = () => {
 };
 
 /**
- * Remove parity binary or partial binary in the userData folder, if it exists.
+ * Remove Parity Ethereum binary or partial binary in the userData folder, if it exists.
  */
 export async function deleteParity() {
   const parityPath = await defaultParityPath();
 
-  // Remove parity binary
+  // Remove Parity Ethereum binary
   try {
     await fsUnlink(parityPath);
   } catch (e) {
     /* Do nothing if error. */
   }
 
-  // Remove parity partial binary (download was still in progress)
+  // Remove Parity Ethereum partial binary (download was still in progress)
   try {
     await fsUnlink(`${parityPath}.part`);
   } catch (e) {
@@ -100,7 +100,7 @@ export async function deleteParity() {
 }
 
 /**
- * Downloads Parity, saves it to Electron's `userData` folder, and returns the
+ * Downloads Parity Ethereum, saves it to Electron's `userData` folder, and returns the
  * path to the downloaded binary once finished.
  */
 export async function fetchParity(
@@ -127,11 +127,11 @@ export async function fetchParity(
           logger()('@parity/electron:main')('Retrying.');
         }
 
-        // Delete any old Parity if it exists, otherwise electron-dl will
+        // Delete any old Parity Ethereum if it exists, otherwise electron-dl will
         // download the new binary with a (1) at the end of the filename
         await deleteParity();
 
-        // Fetch the metadata of the correct version of parity
+        // Fetch the metadata of the correct version of Parity Ethereum
         const metadataUrl = `${VANITY_URL}?version=${parityChannel}&os=${getOs()}&architecture=${getArch()}`;
         logger()('@parity/electron:main')(`Downloading from ${metadataUrl}.`);
         const { data } = await axios.get(metadataUrl);
@@ -178,7 +178,7 @@ export async function fetchParity(
         // Binary is ready to be used: remove `.part` from filename
         await fsRename(downloadPath, await defaultParityPath());
 
-        // Double-check that Parity exists now.
+        // Double-check that Parity Ethereum exists now.
         return getParityPath();
       },
       {

--- a/packages/electron/src/getParityPath.ts
+++ b/packages/electron/src/getParityPath.ts
@@ -17,7 +17,7 @@ import logger from './utils/logger';
 const fsStat = promisify(stat);
 
 /**
- * The default path to install parity, in case there's no other instance found
+ * The default path to install Parity Ethereum, in case there's no other instance found
  * on the machine.
  */
 export function defaultParityPath() {
@@ -29,7 +29,7 @@ export function defaultParityPath() {
 }
 
 /**
- * The real parity path, will be populated after doesParityExist Promise resolves.
+ * The real Parity Ethereum path, will be populated after doesParityExist Promise resolves.
  *
  * @ignore
  */
@@ -49,12 +49,12 @@ const isParityInPath = async () => {
 };
 
 /**
- * Test if Parity is in the common OS locations.
+ * Test if Parity Ethereum is in the common OS locations.
  *
  * @ignore
  */
 const isParityInOs = async (): Promise<string> => {
-  // OS locations to test if parity binary exists
+  // OS locations to test if `parity` binary exists
   const locations: {
     [key: string]: string[];
   } = {
@@ -70,7 +70,7 @@ const isParityInOs = async (): Promise<string> => {
 };
 
 /**
- * Test is Parity is already downloaded in electron app's userData folder.
+ * Test if Parity Ethereum is already downloaded in Electron app's userData folder.
  *
  * @ignore
  */
@@ -81,25 +81,25 @@ const isParityInUserData = async () => {
 };
 
 /**
- * This function checks if parity has been installed on the local machine:
+ * This function checks if Parity Ethereum has been installed on the local machine:
  * - first check if the program is in $PATH, using `command-exists`
- * - then check the OS default installation dir if a parity folder exists
- * - finally check fether's own userData folder
+ * - then check the OS default installation dir if a Parity Ethereum folder exists
+ * - finally check Fether's own userData folder
  * This function should run in node env.
  *
  * @ignore
- * @return Promise<string> - Resolves to a string which is the command to run parity.
+ * @return Promise<string> - Resolves to a string which is the command to run Parity Ethereum.
  */
 const doesParityExist = () =>
   isParityInPath()
     .catch(isParityInOs)
     .catch(isParityInUserData)
     .catch(_ => {
-      throw new Error('Parity not found.');
+      throw new Error('Parity Ethereum not found.');
     });
 
 /**
- * Returns the path to Parity, or throws if parity is not found.
+ * Returns the path to Parity Ethereum, or throws if Parity Ethereum is not found.
  */
 export async function getParityPath() {
   if (parityPath) {
@@ -109,11 +109,11 @@ export async function getParityPath() {
     const path = await doesParityExist();
     parityPath = path; // Save the final result in module variable
     logger()('@parity/electron:main')(
-      `Parity found on machine, can be run with "${path}".`
+      `Parity Ethereum found on machine, can be run with "${path}".`
     );
     return path;
   } catch (err) {
-    logger()('@parity/electron:main')(`Parity not found on machine.`);
+    logger()('@parity/electron:main')(`Parity Ethereum not found on machine.`);
     throw err;
   }
 }

--- a/packages/electron/src/isParityRunning.ts
+++ b/packages/electron/src/isParityRunning.ts
@@ -15,7 +15,7 @@ interface IsParityRunningOptions {
 }
 
 /**
- * Detect if another instance of parity is already running or not. To achieve
+ * Detect if another instance of Parity Ethereum is already running or not. To achieve
  * that, we just ping on the common hosts.
  */
 export async function isParityRunning(
@@ -32,7 +32,7 @@ export async function isParityRunning(
     };
 
     /**
-     * Try to ping these hosts to test if Parity is running.
+     * Try to ping these hosts to test if Parity Ethereum is running.
      */
     const hostsToPing = [
       'http://127.0.0.1:8545',
@@ -46,7 +46,7 @@ export async function isParityRunning(
       axios.get(host)
         .then(_ => {
           logger()('@parity/electron:main')(
-            `Another instance of parity is already running on ${host}, skip running local instance.`
+            `Another instance of Parity Ethereum is already running on ${host}, skip running local instance.`
           );
           resolve(true)
         })

--- a/packages/electron/src/runParity.ts
+++ b/packages/electron/src/runParity.ts
@@ -24,11 +24,11 @@ const fsChmod = promisify(chmod);
 /**
  * @ignore
  */
-let parity: ChildProcess = null; // Will hold the running parity instance
+let parity: ChildProcess = null; // Will hold the running Parity Ethereum instance
 
 /**
- * These are errors output by parity, which we should ignore (i.e. don't
- * panic). They happen when an instance of parity is already running, and
+ * These are errors output by Parity Etherum, which we should ignore (i.e. don't
+ * panic). They happen when an instance of Parity Ethereum is already running, and
  * parity-electron tries to launch another one.
  *
  * @ignore
@@ -39,7 +39,7 @@ const catchableErrors = [
 ];
 
 /**
- * Spawns a child process to run Parity.
+ * Spawns a child process to run Parity Ethereum.
  */
 export async function runParity(
   options: RunParityOptions = {
@@ -58,7 +58,7 @@ export async function runParity(
   };
   const parityPath = await getParityPath();
 
-  // Some users somehow had no +x on the parity binary after downloading
+  // Some users somehow had no +x on the `parity` binary after downloading
   // it. We try to set it here (no guarantee it will work, we might not
   // have rights to do it).
   try {
@@ -69,20 +69,20 @@ export async function runParity(
 
   return new Promise((resolve, reject) => {
 
-    let logLastLine = ''; // Always contains last line of the Parity logs
+    let logLastLine = ''; // Always contains last line of the Parity Ethereum logs
 
-    // Run an instance of parity with the correct flags
+    // Run an instance of Parity Ethereum with the correct flags
     parity = spawn(parityPath, flags);
     logger()('@parity/electron:main')(logCommand(parityPath, flags));
 
     // Save in memory the last line of the log file, for handling error
     const callback = (data: Buffer) => {
-      // `parity signer new-token` requires Parity's folders to have already
-      // been created. In order to be able to run `parity signer new-token`
-      // right after runParity resolves, we want runParity to resolve once
-      // Parity was launched and has set up its folders (if it's a first run).
-      // As a heuristic, we resolve as soon as Parity outputs to stdout/stderr:
-      // this happens just after the directories have been set up,
+      // `parity signer new-token` requires Parity Ethereum's folders to have
+      // already been created. In order to be able to run `parity signer new-token`
+      // right after runParity resolves, we want runParity to resolve once Parity
+      // Ethereum was launched and has set up its folders (if it's a first run).
+      // As a heuristic, we resolve as soon as Parity Ethereum outputs to
+      // stdout/stderr: this happens just after the directories have been set up,
       // see https://git.io/fx9JE
       resolve();
 
@@ -102,16 +102,16 @@ export async function runParity(
         return;
       }
 
-      // When there's already an instance of parity running, then the log
+      // When there's already an instance of `parity` running, then the log
       // is logging a particular line, see below. In this case, we just
-      // silently ignore our local instance, and let the 1st parity
+      // silently ignore our local instance, and let the 1st `parity`
       // instance be the main one.
       if (
         logLastLine &&
         catchableErrors.some(error => logLastLine.includes(error))
       ) {
         logger()('@parity/electron:main')(
-          'Another instance of parity is running, closing local instance.'
+          'Another instance of Parity Ethereum is running, closing local instance.'
         );
         return;
       }

--- a/packages/electron/src/signerNewToken.ts
+++ b/packages/electron/src/signerNewToken.ts
@@ -10,7 +10,7 @@ import logCommand from './utils/logCommand';
 import logger from './utils/logger';
 
 /**
- * Runs parity signer new-token and resolves with a new secure token to be
+ * Runs `parity signer new-token` and resolves with a new secure token to be
  * used in a dapp. Rejects if no token could be extracted.
  */
 export function signerNewToken(): Promise<string> {

--- a/packages/light.js/docs/concepts/light-client-development.md
+++ b/packages/light.js/docs/concepts/light-client-development.md
@@ -62,9 +62,9 @@ setTimeout(function update() {
 });
 ```
 
-### 3. Pubsub
+### 3. Pub-sub
 
-A more intelligent way would be to have a "push" mechanism instead of a "pull" mechanism. With pubsub, we can subscribe to changes on the network. Here, we subscribing to new headers, and updating balance each time we receive a new header.
+A more intelligent way would be to have a "push" mechanism instead of a "pull" mechanism. With pub-sub, we can subscribe to changes on the network. Here, we subscribing to new headers, and updating balance each time we receive a new header.
 
 ```javascript
 const contract = web3.eth.Contract(ABI, '0x00..ff');

--- a/packages/light.js/docs/concepts/rpc-observables-properties.md
+++ b/packages/light.js/docs/concepts/rpc-observables-properties.md
@@ -78,13 +78,13 @@ import { blockNumber$ } from '@parity/light.js';
 
 const myObs$ = blockNumber$();
 console.log(blockNumber$.frequency); // [onEveryBlock$]
-// Note: onEveryBlock$ creates a pubsub on `eth_blockNumber`
+// Note: onEveryBlock$ creates a pub-sub on `eth_blockNumber`
 
 const subscription = myObs$.subscribe(console.log);
-// Creates a pubsub subscription
+// Creates a pub-sub subscription
 
 // Some other code...
 
 subscription.unsubscribe();
-// Drops the pubsub subscription
+// Drops the pub-sub subscription
 ```

--- a/packages/light.js/docs/concepts/rpc-observables.md
+++ b/packages/light.js/docs/concepts/rpc-observables.md
@@ -30,7 +30,7 @@ These are the most important fields of `MetaData`, which we will explain.
 
 ## Main Idea
 
-We believe that data streams are an intuitive way to express events happening on the Ethereum blockchain. The most obvious example is the pubsub pattern we described [before](/concepts/light-client-development.html#pubsub), where we wanted to fetch the balance on every new block.
+We believe that data streams are an intuitive way to express events happening on the Ethereum blockchain. The most obvious example is the pub-sub pattern we described [before](/concepts/light-client-development.html#pubsub), where we wanted to fetch the balance on every new block.
 
 It's intuitive to have an Observable, called `onEveryBlock$`, that would fire an event each time it receives a new block from the network. Then, every time it fires, we declaratively make an JSONRPC call to `eth_getBalance`. Into code, it looks like this:
 

--- a/packages/light.js/src/api.ts
+++ b/packages/light.js/src/api.ts
@@ -27,7 +27,7 @@ export const setApi = (newApi: any) => {
   api = newApi;
   if (!api.isPubSub) {
     console.warn(
-      `Current provider does not support pubsub. @parity/light.js will poll every second to listen to changes.`
+      `Current provider does not support pub-sub. @parity/light.js will poll every second to listen to changes.`
     );
   }
 };

--- a/packages/light.js/src/frequency/frequency.spec.ts
+++ b/packages/light.js/src/frequency/frequency.spec.ts
@@ -88,6 +88,6 @@ Object.keys(frequency).forEach(key =>
   testFrequency(
     key,
     (frequency as FrequencyMap)[key as FrequencyKey],
-    key.includes('Account') ? ['foo'] : 4 // Give string[] for accounts pubsub, or number elsewhere
+    key.includes('Account') ? ['foo'] : 4 // Give string[] for accounts pub-sub, or number elsewhere
   )
 );

--- a/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
+++ b/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
@@ -13,7 +13,7 @@ it('should return an Observable', () => {
   expect(isObservable(createPubsubObservable('fake_method'))).toBe(true);
 });
 
-it('should fire an event when pubsub publishes', done => {
+it('should fire an event when pub-sub publishes', done => {
   setApi(resolveApi());
   createPubsubObservable('fake_method').subscribe(data => {
     expect(data).toBe('foo');
@@ -21,7 +21,7 @@ it('should fire an event when pubsub publishes', done => {
   });
 });
 
-it('should fire an error when pubsub errors', done => {
+it('should fire an error when pub-sub errors', done => {
   setApi(rejectApi());
   createPubsubObservable('fake_method').subscribe(null, err => {
     expect(err).toEqual(new Error('bar'));
@@ -29,7 +29,7 @@ it('should fire an error when pubsub errors', done => {
   });
 });
 
-it('should fire an event when polling pubsub publishes', done => {
+it('should fire an event when polling pub-sub publishes', done => {
   setApi(resolveApi('foo', false));
   createPubsubObservable('fake_method').subscribe(data => {
     expect(data).toBe('foo');
@@ -37,7 +37,7 @@ it('should fire an event when polling pubsub publishes', done => {
   });
 });
 
-it('should fire an error when polling pubsub errors', done => {
+it('should fire an error when polling pub-sub errors', done => {
   setApi(rejectApi(new Error('bar'), false));
   createPubsubObservable('fake_method').subscribe(null, err => {
     expect(err).toEqual(new Error('bar'));

--- a/packages/light.js/src/frequency/utils/createPubsubObservable.ts
+++ b/packages/light.js/src/frequency/utils/createPubsubObservable.ts
@@ -13,7 +13,7 @@ import { createApiFromProvider, getApi } from '../../api';
 import { distinctReplayRefCount } from '../../utils/operators/distinctReplayRefCount';
 
 /**
- * Given an api, returns an Observable that emits on each pubsub event.
+ * Given an api, returns an Observable that emits on each pub-sub event.
  * Pure function version of {@link createPubsubObservable}.
  *
  * @ignore
@@ -22,7 +22,7 @@ const createPubsubObservableWithApi = memoizee(
   <T>(pubsub: string, api: any) => {
     const [namespace, method] = pubsub.split('_');
 
-    // There's a chance the provider doesn't support pubsub, for example
+    // There's a chance the provider doesn't support pub-sub, for example
     // MetaMaskProvider. In this case, as suggested on their Github, the best
     // solution for now is to poll.
     if (!api.isPubSub) {
@@ -57,7 +57,7 @@ const createPubsubObservableWithApi = memoizee(
 );
 
 /**
- * Given a provider, returns an Observable that emits on each pubsub event.
+ * Given a provider, returns an Observable that emits on each pub-sub event.
  *
  * @ignore
  * @example onAccountsChanged$, onEveryBlock$...

--- a/packages/light.js/src/utils/testHelpers/mockApi.ts
+++ b/packages/light.js/src/utils/testHelpers/mockApi.ts
@@ -48,7 +48,7 @@ const createApi = (
           : () => Promise.resolve(resolveWith);
       });
 
-      // Create pubsub on apiObject
+      // Create pub-sub on apiObject
       apiObject.pubsub = apiObject.pubsub || {
         unsubscribe: () => Promise.resolve()
       };


### PR DESCRIPTION
* Remove no longer used packages/contracts types file

* Rename Ethcore to Parity

* Change license header from 2017 to 2018 validity

* Create Input___ types in packages/api to fix linting errors

* Fix typo 'receiving' and 'initialises'

* Rename 'pubsub' to 'pub-sub', 'rpc' to 'RPC', and 'abi' to 'ABI', and 'ether' to 'Ether' (when referring to denomination), and 'electron' to 'Electron', and 'parity' to 'Parity' or 'Parity Ethereum' (as applicable) in comments. Refer to 'parity binary' as '`parity` binary'

* Move types Api, Contract, and ContractInstance to '@parity/api/src/types'

* Reword to 'The message of the RPC call.'

* FIXME added since cannot find file '../../test/e2e/ethapi' used in unit test

* FIXME added for test description 'returns and the chain'