### PR TITLE
Parse metamask responses

### DIFF
--- a/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
+++ b/packages/light.js/src/frequency/utils/createPubsubObservable.spec.ts
@@ -37,6 +37,14 @@ it('should fire an event when polling pubsub publishes', done => {
   });
 });
 
+it('should fire an event when polling pubsub publishes, with object', done => {
+  setApi(resolveApi({ result: 'foo' }, false));
+  createPubsubObservable('fake_method').subscribe(data => {
+    expect(data).toBe('foo');
+    done();
+  });
+});
+
 it('should fire an error when polling pubsub errors', done => {
   setApi(rejectApi(new Error('bar'), false));
   createPubsubObservable('fake_method').subscribe(null, err => {

--- a/packages/light.js/src/frequency/utils/createPubsubObservable.ts
+++ b/packages/light.js/src/frequency/utils/createPubsubObservable.ts
@@ -33,7 +33,17 @@ const createPubsubObservableWithApi = memoizee(
       );
 
       return timer(0, 1000).pipe(
-        switchMap(() => api[namespace][method]())
+        switchMap(() =>
+          api[namespace][method]().then((response: any) => {
+            // For responses by MetaMask, the object is not parsed by
+            // `@parity/api`. We parse it manually here.
+            // TODO Put this logic in `@parity/api`
+            if (typeof response === 'object' && response.result !== undefined) {
+              return response.result;
+            }
+            return response;
+          })
+        )
       ) as Observable<T>;
     }
 

--- a/packages/light.js/src/utils/testHelpers/mockApi.ts
+++ b/packages/light.js/src/utils/testHelpers/mockApi.ts
@@ -34,7 +34,7 @@ const listOfMockRps: { [index: string]: string[] } = {
  * @ignore
  */
 const createApi = (
-  resolveWith: string | { error: string } | Error,
+  resolveWith: string | object | { error: string } | Error,
   isPubSub: boolean,
   isError: boolean
 ) => {
@@ -111,6 +111,6 @@ export const rejectApi = (
  * @ignore
  */
 export const resolveApi = (
-  resolveWith: string | { error: string } = 'foo',
+  resolveWith: string | object | { error: string } = 'foo',
   isPubsub: boolean = true
 ) => createApi(resolveWith, isPubsub, false);


### PR DESCRIPTION
This is a temporary workaround, the real issue is #48.

closes #47.