### PR TITLE
Update installation.md to fix error by using `yarn add` instead of `yarn install`

### DIFF
--- a/packages/light.js/docs/getting-started/installation.md
+++ b/packages/light.js/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## From npm
 
 ```bash
-yarn install rxjs @parity/light.js # Or npm install
+yarn add rxjs @parity/light.js # Or npm install
 ```
 
 RxJS is a needed peer-dependency.


### PR DESCRIPTION
Fixes error:
```
error 'install' has been replaced with 'add' to add new dependencies. Run "yarn add rxjs @parity/light.js" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```