### PR TITLE
Fix #77: don't show password in plaintext in console

### DIFF
--- a/packages/api/src/transport/ws/ws.js
+++ b/packages/api/src/transport/ws/ws.js
@@ -261,6 +261,11 @@ class Ws extends JsonRpcBase {
 
         // Don't print error if request rejected or not is not yet up...
         if (!/(rejected|not yet up)/.test(result.error.message)) {
+          var dangerous_methods = ['signer_confirmRequest', 'signer_confirmRequestWithToken'];
+          if (dangerous_methods.includes(method)) {
+            params.pop();
+          }
+
           console.error(`${method}(${JSON.stringify(params)}): ${result.error.code}: ${result.error.message}`);
         }
 


### PR DESCRIPTION
@ltfschoen, I've made this edit to address the downstream bug in Fether - https://github.com/paritytech/fether/issues/317

I'm not convinced this is actually a security bug however since:
a) it only logs when the password is incorrect, and
b) in production the developer console would not be accessible,

though of course, I'm all ears to learning about why it actually is an issue.