### PR TITLE
Support parity_getBlockReceipts in API

### DIFF
--- a/packages/api/src/format/output.ts
+++ b/packages/api/src/format/output.ts
@@ -119,6 +119,14 @@ export function outBlock (block: SerializedBlock) {
   return result;
 }
 
+export function outBlockReceipts (receipts: SerializedReceipt[]) {
+  if (receipts) {
+    return receipts.map(outReceipt);
+  }
+
+  return receipts;
+}
+
 export function outChainStatus (status?: SerializedChainStatus) {
   const result: ChainStatus = {};
   if (status) {

--- a/packages/api/src/pubsub/parity/parity.js
+++ b/packages/api/src/pubsub/parity/parity.js
@@ -16,7 +16,7 @@
 
 const PubsubBase = require('../pubsubBase');
 const { inAddress, inBlockNumber, inData, inHex, inDeriveHash, inDeriveIndex } = require('../../format/input');
-const { outAccountInfo, outAddress, outBlock, outChainStatus, outHistogram, outHwAccountInfo, outNodeKind, outNumber, outPeers, outTransaction, outAddresses, outRecentDapps, outVaultMeta } = require('../../format/output');
+const { outAccountInfo, outAddress, outBlock, outBlockReceipts, outChainStatus, outHistogram, outHwAccountInfo, outNodeKind, outNumber, outPeers, outTransaction, outAddresses, outRecentDapps, outVaultMeta } = require('../../format/output');
 
 class Parity extends PubsubBase {
   constructor (provider) {
@@ -267,6 +267,14 @@ class Parity extends PubsubBase {
       error
         ? callback(error)
         : callback(null, outBlock(data));
+    }, [inBlockNumber(blockNumber)]);
+  }
+
+  getBlockReceipts (callback, blockNumber = 'latest') {
+    return this.addListener(this._api, 'parity_getBlockReceipts', (error, data) => {
+      error
+        ? callback(error)
+        : callback(null, outBlockReceipts(data));
     }, [inBlockNumber(blockNumber)]);
   }
 

--- a/packages/api/src/rpc/parity/parity.js
+++ b/packages/api/src/rpc/parity/parity.js
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 const { inAddress, inAddresses, inBlockNumber, inData, inDeriveHash, inDeriveIndex, inHex, inNumber16, inOptions } = require('../../format/input');
-const { outAccountInfo, outAddress, outAddresses, outBlock, outChainStatus, outHistogram, outHwAccountInfo, outNodeKind, outNumber, outPeers, outRecentDapps, outTransaction, outVaultMeta } = require('../../format/output');
+const { outAccountInfo, outAddress, outAddresses, outBlock, outBlockReceipts, outChainStatus, outHistogram, outHwAccountInfo, outNodeKind, outNumber, outPeers, outRecentDapps, outTransaction, outVaultMeta } = require('../../format/output');
 
 class Parity {
   constructor (provider) {
@@ -220,6 +220,12 @@ class Parity {
     return this._provider
       .send('parity_getBlockHeaderByNumber', inBlockNumber(blockNumber))
       .then(outBlock);
+  }
+
+  getBlockReceipts (blockNumber = 'latest') {
+    return this._provider
+      .send('parity_getBlockReceipts', inBlockNumber(blockNumber))
+      .then(outBlockReceipts)
   }
 
   getDappAddresses (dappId) {


### PR DESCRIPTION
 - Implemented `getBlockReceipts` for use with RPC/WS
 - Utilised existing infrastructure/tests for deserializing output with `outReceipt`
 - Noted `outReceipt` doesn't convert `status` hex to number but avoided changing due to knock on

Resolves #68 