### PR TITLE
feat: fix build errored in #197

### DIFF
--- a/packages/light.js/src/utils/testHelpers/mockApi.ts
+++ b/packages/light.js/src/utils/testHelpers/mockApi.ts
@@ -40,7 +40,9 @@ const createApi = (
 ) => {
 
   const getResolveValue = () =>
-    (typeof resolveValueOrFunction === 'function' ? resolveValueOrFunction() : resolveValueOrFunction);
+    // TODO Casting as Function manually, or else we get:
+    // "Cannot invoke an expression whose type lacks a call signature. Type 'Function | (() => any)' has no compatible call signatures."
+    (typeof resolveValueOrFunction === 'function' ? (resolveValueOrFunction as Function)() : resolveValueOrFunction);
 
   const result = Object.keys(listOfMockRps).reduce(
     (apiObject, namespace: string) => {


### PR DESCRIPTION
#197 produced an errored build on CI (https://travis-ci.org/paritytech/js-libs/builds/501492154). This PR attempts to fix it.

I'm putting `feat:` here because #197 was a `feat:` and didn't pass.