### PR TITLE
feat: add versionInfo$

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.1.13",
     "typescript": "^3.1.6"
-  },
-  "dependencies": {
-    "@parity/api": "5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.1.13",
     "typescript": "^3.1.6"
+  },
+  "dependencies": {
+    "@parity/api": "5.0.0"
   }
 }

--- a/packages/electron/src/runParity.ts
+++ b/packages/electron/src/runParity.ts
@@ -12,6 +12,7 @@ import logCommand from './utils/logCommand';
 import logger from './utils/logger';
 
 interface RunParityOptions {
+  parityPath?: string;
   flags: string[];
   onParityError: (error: Error) => void;
 }
@@ -56,7 +57,7 @@ export async function runParity (
     },
     ...options
   };
-  const parityPath = await getParityPath();
+  const parityPath = options.parityPath || await getParityPath();
 
   // Some users somehow had no +x on the parity binary after downloading
   // it. We try to set it here (no guarantee it will work, we might not

--- a/packages/electron/src/signerNewToken.ts
+++ b/packages/electron/src/signerNewToken.ts
@@ -13,11 +13,11 @@ import logger from './utils/logger';
  * Runs parity signer new-token and resolves with a new secure token to be
  * used in a dapp. Rejects if no token could be extracted.
  */
-export function signerNewToken (): Promise<string> {
+export function signerNewToken (options?: { parityPath: string; }): Promise<string> {
   return new Promise(async (resolve, reject) => {
     logger()('@parity/electron:main')('Requesting new token.');
 
-    const parityPath = await getParityPath();
+    const parityPath = options && options.parityPath || await getParityPath();
 
     // Generate a new token
     const paritySigner = spawn(parityPath, ['signer', 'new-token']);

--- a/packages/light.js/src/index.ts
+++ b/packages/light.js/src/index.ts
@@ -24,6 +24,7 @@ export const {
   peerCount$,
   post$,
   postRaw$,
-  syncStatus$
+  syncStatus$,
+  versionInfo$
 } = rpc;
 export default { setApi, setProvider };

--- a/packages/light.js/src/rpc/parity.ts
+++ b/packages/light.js/src/rpc/parity.ts
@@ -48,6 +48,6 @@ export function versionInfo$ (options?: RpcObservableOptions) {
     calls: ['parity_versionInfo'],
     frequency: [frequency.onStartup$],
     name: 'versionInfo$',
-    pipes: api => [switchMapPromise(() => api.parity.versionInfo())]
+    pipes: api => [switchMapPromise(() => api.parity.versionInfo(), { emitErrors: true })]
   })(options)();
 }

--- a/packages/light.js/src/rpc/parity.ts
+++ b/packages/light.js/src/rpc/parity.ts
@@ -37,3 +37,17 @@ export function chainName$ (options?: RpcObservableOptions) {
     pipes: api => [switchMapPromise(() => api.parity.chain())]
   })(options)();
 }
+
+/**
+ * Get the version info of Parity Ethereum. Calls `parity_versionInfo`.
+ *
+ * @return - An Observable containing the version object: {major, minor, patch}
+ */
+export function versionInfo$ (options?: RpcObservableOptions) {
+  return createRpc$<any, string>({
+    calls: ['parity_versionInfo'],
+    frequency: [frequency.onStartup$],
+    name: 'versionInfo$',
+    pipes: api => [switchMapPromise(() => api.parity.versionInfo())]
+  })(options)();
+}

--- a/packages/light.js/src/rpc/rpc.spec.ts
+++ b/packages/light.js/src/rpc/rpc.spec.ts
@@ -7,14 +7,11 @@ import * as Api from '@parity/api';
 
 import isObservable from '../utils/isObservable';
 import {
-  MockProvider,
-  rejectApi,
   resolveApi
 } from '../utils/testHelpers/mockApi';
 import rpc from './rpc';
 import { RpcKey, RpcMap, RpcObservable } from '../types';
 import { setApi } from '../api';
-import sleep from '../utils/testHelpers/sleep';
 
 /*
  * Mock the Api of the RPC dependencies' observables

--- a/packages/light.js/src/utils/operators/switchMapPromise.spec.ts
+++ b/packages/light.js/src/utils/operators/switchMapPromise.spec.ts
@@ -9,10 +9,41 @@ import mockRpc$ from '../testHelpers/mockRpc';
 import { rejectApi, resolveApi } from '../testHelpers/mockApi';
 import { switchMapPromise } from './switchMapPromise';
 
-it('should fire an error when the promise throws', done => {
+it('should not error when the promise resolves with an error', done => {
+  mockRpc$()
+    .pipe(switchMapPromise(resolveApi({ error: 'bar' }).fake.method))
+    .subscribe(undefined, () => done.fail('It should not error.'));
+
+  // If after 0.1s, nothing has been called, then our Observable has not fired
+  // any event, which is what we want
+  setTimeout(done, 100);
+});
+
+it('should not error when the promise rejects', done => {
+  mockRpc$()
+    .pipe(switchMapPromise(rejectApi().fake.method))
+    .subscribe(undefined, () => done.fail('It should not error.'));
+
+  // If after 0.1s, nothing has been called, then our Observable has not fired
+  // any event, which is what we want
+  setTimeout(done, 100);
+});
+
+it('should fire an error when the promise resolves with an error', done => {
   mockRpc$()
     .pipe(
-      switchMapPromise(rejectApi(new Error('boo')).fake.method)
+      switchMapPromise(rejectApi(new Error('boo')).fake.method, { emitErrors: true })
+    )
+    .subscribe(undefined, err => {
+      expect(err).toEqual(new Error('boo'));
+      done();
+    });
+});
+
+it('should fire an error when the promise rejects', done => {
+  mockRpc$()
+    .pipe(
+      switchMapPromise(rejectApi(new Error('boo')).fake.method, { emitErrors: true })
     )
     .subscribe(undefined, err => {
       expect(err).toEqual(new Error('boo'));

--- a/packages/light.js/src/utils/operators/switchMapPromise.spec.ts
+++ b/packages/light.js/src/utils/operators/switchMapPromise.spec.ts
@@ -9,24 +9,15 @@ import mockRpc$ from '../testHelpers/mockRpc';
 import { rejectApi, resolveApi } from '../testHelpers/mockApi';
 import { switchMapPromise } from './switchMapPromise';
 
-it('should not error when the promise resolves with an error', done => {
+it('should fire an error when the promise throws', done => {
   mockRpc$()
-    .pipe(switchMapPromise(resolveApi({ error: 'bar' }).fake.method))
-    .subscribe(undefined, () => done.fail('It should not error.'));
-
-  // If after 0.1s, nothing has been called, then our Observable has not fired
-  // any event, which is what we want
-  setTimeout(done, 100);
-});
-
-it('should not error when the promise rejects', done => {
-  mockRpc$()
-    .pipe(switchMapPromise(rejectApi().fake.method))
-    .subscribe(undefined, () => done.fail('It should not error.'));
-
-  // If after 0.1s, nothing has been called, then our Observable has not fired
-  // any event, which is what we want
-  setTimeout(done, 100);
+    .pipe(
+      switchMapPromise(rejectApi(new Error('boo')).fake.method)
+    )
+    .subscribe(undefined, err => {
+      expect(err).toEqual(new Error('boo'));
+      done();
+    });
 });
 
 it('should fire the correct value when the promise resolves', done => {

--- a/packages/light.js/src/utils/operators/switchMapPromise.ts
+++ b/packages/light.js/src/utils/operators/switchMapPromise.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import { catchError, switchMap } from 'rxjs/operators';
-import { empty, from, Observable } from 'rxjs';
+import { from, Observable, throwError } from 'rxjs';
 
 /**
  * SwitchMap to an Observable.from. The Observable.from will return an empty
@@ -36,7 +36,7 @@ export const switchMapPromise = <T,U>(promise: () => Promise<U>) => (
             )
           );
           console.groupEnd();
-          return empty();
+          return throwError(err) as Observable<U>;
         })
       )
     )

--- a/packages/light.js/src/utils/testHelpers/mockApi.ts
+++ b/packages/light.js/src/utils/testHelpers/mockApi.ts
@@ -25,7 +25,7 @@ const listOfMockRps: { [index: string]: string[] } = {
   eth: ['accounts', 'blockNumber', 'chainId', 'getBalance', 'getTransactionCount', 'newHeads', 'syncing'],
   fake: ['method'],
   net: ['peerCount'],
-  parity: ['accountsInfo', 'chain', 'postTransaction']
+  parity: ['accountsInfo', 'chain', 'postTransaction', 'versionInfo']
 };
 
 /**


### PR DESCRIPTION
Some changes required for https://github.com/paritytech/fether/issues/204

- Add versionInfo$
- Rejected/errored RPCs now make the observable emit an error if `options.emitErrors === true`. This is needed to check the version of the running instance of Parity (part of https://github.com/paritytech/fether/issues/204): if the RPC parity_versionInfo fails, we know that we're running Parity Ethereum <v2.4.1 (in fether-react)
- Add `parityPath` to runParity and signerNewToken, which lets us run those commands on the bundled Parity binary