### PR TITLE
fix: downgrade es6-error

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,7 @@
     "@parity/abi": "^5.1.0",
     "bignumber.js": "^8.0.1",
     "blockies": "0.0.2",
-    "es6-error": "4.1.1",
+    "es6-error": "4.0.2",
     "es6-promise": "^4.1.1",
     "eventemitter3": "^3.1.0",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,10 +2581,10 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.9, es5-ext@~
     es6-symbol "~3.1.1"
     next-tick "1"
 
-es6-error@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
-  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
+es6-error@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
+  integrity sha1-7sXHJurO9Rt/a3PCDbbhsTsGnJg=
 
 es6-iterator@^2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
see https://github.com/bjyoungblood/es6-error/issues/39
fixes the TransportError constructor throwing in Fether because `super(args)` is not defined